### PR TITLE
Support getting extension by subtype.

### DIFF
--- a/context-test/src/main/java/org/creek/test/service/context/KeepSpotbugsHappy.java
+++ b/context-test/src/main/java/org/creek/test/service/context/KeepSpotbugsHappy.java
@@ -17,4 +17,4 @@
 package org.creek.test.service.context;
 
 @SuppressWarnings("unused") // Spotbugs fails if there are no source files...
-final class KeepSpotbugsHappy {}
+interface KeepSpotbugsHappy {}

--- a/context-test/src/test/java/org/creek/test/service/context/CreekServicesTest.java
+++ b/context-test/src/test/java/org/creek/test/service/context/CreekServicesTest.java
@@ -52,11 +52,6 @@ class CreekServicesTest {
 
     @BeforeEach
     void setUp() {
-        assertThat(
-                "Invoke constructor for code coverage",
-                new KeepSpotbugsHappy(),
-                is(notNullValue()));
-
         when(serviceDescriptor.name()).thenReturn("the-service");
         when(serviceDescriptor.resources()).thenCallRealMethod();
     }

--- a/context/src/main/java/org/creek/internal/service/context/ContextBuilder.java
+++ b/context/src/main/java/org/creek/internal/service/context/ContextBuilder.java
@@ -185,9 +185,7 @@ public final class ContextBuilder implements CreekServices.Builder {
         }
 
         private static String type(final Collection<? extends CreekExtension> extensions) {
-            return extensions.isEmpty()
-                    ? "Unknown"
-                    : extensions.iterator().next().getClass().getName();
+            return extensions.iterator().next().getClass().getName();
         }
 
         private static String locations(final Collection<? extends CreekExtension> extensions) {

--- a/context/src/test/java/org/creek/internal/service/context/ContextTest.java
+++ b/context/src/test/java/org/creek/internal/service/context/ContextTest.java
@@ -42,7 +42,7 @@ class ContextTest {
 
     @Mock private Clock clock;
     @Mock private TestExtension0 ext0;
-    @Mock private TestExtension1 ext1;
+    @Mock private PrivateExtensionImpl ext1;
     private Context ctx;
 
     @BeforeEach
@@ -60,35 +60,30 @@ class ContextTest {
 
     @Test
     void shouldGetExtensionByType() {
-        assertThat(ctx.extension(ext0.getClass()), is(ext0));
-        assertThat(ctx.extension(ext1.getClass()), is(ext1));
+        assertThat(ctx.extension(TestExtension0.class), is(ext0));
     }
 
     @Test
-    void shouldThrowMeaningfulExceptionIfTwoExtensionsHaveTheSameType() {
-        // When:
-        final Exception e =
-                assertThrows(Exception.class, () -> new Context(clock, List.of(ext0, ext0)));
+    void shouldGetExtensionBySubType() {
+        assertThat(ctx.extension(PublicExtensionInterface.class), is(ext1));
+    }
 
-        // Then:
-        assertThat(
-                e.getMessage(),
-                is(
-                        "Multiple extensions found with the same type. This is not supported. type: "
-                                + ext0.getClass()));
+    @Test
+    void shouldGetFirstExtensionThatMatches() {
+        assertThat(ctx.extension(CreekExtension.class), is(ext0));
     }
 
     @Test
     void shouldThrowExceptionOnGetOfUnregisteredExtensionType() {
         // When:
         final Exception e =
-                assertThrows(Exception.class, () -> ctx.extension(CreekExtension.class));
+                assertThrows(Exception.class, () -> ctx.extension(UnknownExtension.class));
 
         // Then:
         assertThat(
                 e.getMessage(),
                 startsWith(
-                        "No extension of requested type is registered: " + CreekExtension.class));
+                        "No extension of requested type is registered: " + UnknownExtension.class));
         assertThat(
                 e.getMessage(),
                 either(containsString(", installed_extensions: [ext0, ext1]"))
@@ -97,5 +92,9 @@ class ContextTest {
 
     private interface TestExtension0 extends CreekExtension {}
 
-    private interface TestExtension1 extends CreekExtension {}
+    private interface PublicExtensionInterface extends CreekExtension {}
+
+    private abstract static class PrivateExtensionImpl implements PublicExtensionInterface {}
+
+    private interface UnknownExtension extends CreekExtension {}
 }

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,3 +1,7 @@
 # Extension
 
 Module containing the types needed to implement an extension to handle resources in Creek.
+
+The types of resources that Creek can understand can be extended by adding extensions. 
+An extension can be registered by adding a jar to the class or module path that exposes a service 
+implementation of `CreekExtensionBuilder`. 

--- a/extension/src/main/java/org/creek/api/service/extension/CreekExtensionBuilder.java
+++ b/extension/src/main/java/org/creek/api/service/extension/CreekExtensionBuilder.java
@@ -24,7 +24,9 @@ import org.creek.api.platform.metadata.ResourceDescriptor;
  * Builder of extension to Creek.
  *
  * <p>Creek will look for extensions using {@link java.util.ServiceLoader} to load instances of
- * {@code CreekExtensionProvider} from the class & module paths.
+ * {@link CreekExtensionBuilder} from the class & module paths. To be loaded by Creek the extension
+ * must be registered in either the {@code module-info.java} file as a {@code provider} of {@link
+ * CreekExtensionBuilder} and/or have a suitable entry in the {@code META-INFO.services} directory.
  */
 public interface CreekExtensionBuilder {
 
@@ -44,7 +46,7 @@ public interface CreekExtensionBuilder {
     /**
      * Registers custom options for an extension with the builder.
      *
-     * <p>Creek will pass all options instances to each extension builder. Implementations can
+     * <p>Creek will pass all options instances to all extension builders. Implementations can
      * ignore any or all options. Creek will throw if no registered extension handles user supplied
      * options.
      *

--- a/extension/src/main/java/org/creek/api/service/extension/CreekExtensions.java
+++ b/extension/src/main/java/org/creek/api/service/extension/CreekExtensions.java
@@ -25,10 +25,10 @@ public final class CreekExtensions {
 
     private CreekExtensions() {}
 
-    /** Instantiate any extensions on the class path. */
+    /** Instantiate any extensions available at runtime. */
     public static List<CreekExtensionBuilder> load() {
         return ServiceLoader.load(CreekExtensionBuilder.class).stream()
                 .map(ServiceLoader.Provider::get)
-                .collect(Collectors.toList());
+                .collect(Collectors.toUnmodifiableList());
     }
 }


### PR DESCRIPTION
Non-public extension implementations should be retrievable by their public subtype.

### Reviewer checklist
- [x] New Modules have `module-info.java` files.
- [x] Public types are well-designed:
    - [x] no public constructors.
    - [x] prefer interface or impl.
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [x] Ensure any appropriate documentation has been added or amended