### PR TITLE
Update to wildcard `ResourceHandler`

### DIFF
--- a/api/src/test/java/org/creekservice/internal/service/api/ComponentModelTest.java
+++ b/api/src/test/java/org/creekservice/internal/service/api/ComponentModelTest.java
@@ -17,6 +17,7 @@
 package org.creekservice.internal.service.api;
 
 import static java.lang.System.lineSeparator;
+import static java.util.regex.Pattern.compile;
 import static java.util.regex.Pattern.quote;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -31,6 +32,7 @@ import java.util.Arrays;
 import java.util.ConcurrentModificationException;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.creekservice.api.platform.metadata.ResourceDescriptor;
 import org.creekservice.api.platform.metadata.ResourceHandler;
@@ -216,28 +218,42 @@ class ComponentModelTest {
         assertThat(
                 e.getMessage(),
                 matchesRegex(
-                        quote(
-                                        "Unknown resource descriptor type: "
-                                                + TestResource.class.getName()
-                                                + lineSeparator()
-                                                + "Are you missing a Creek extension on the class or module path?"
-                                                + lineSeparator()
-                                                + "Known resource types: ["
-                                                + lineSeparator())
-                                + ".*"
-                                + quote(lineSeparator() + "]")));
+                        compile(
+                                quote(
+                                                "Unknown resource descriptor type: "
+                                                        + TestResource.class.getName()
+                                                        + lineSeparator()
+                                                        + "Are you missing a Creek extension on the class or module path?"
+                                                        + lineSeparator()
+                                                        + "Known resource types: ["
+                                                        + lineSeparator())
+                                        + ".*"
+                                        + quote(lineSeparator() + "]"),
+                                Pattern.DOTALL)));
 
         assertThat(
                 e.getMessage(),
                 matchesRegex(
-                        quote(lineSeparator() + "\t" + TestResource2.class.getName())
-                                + " \\(file:/.*\\)"));
+                        compile(
+                                ".*"
+                                        + quote(
+                                                lineSeparator()
+                                                        + "\t"
+                                                        + TestResource2.class.getName())
+                                        + " \\(file:/[^)]*\\).*",
+                                Pattern.DOTALL)));
 
         assertThat(
                 e.getMessage(),
                 matchesRegex(
-                        quote("," + lineSeparator() + "\t" + TestResource3.class.getName())
-                                + " \\(file:/.*\\)"));
+                        compile(
+                                ".*"
+                                        + quote(
+                                                lineSeparator()
+                                                        + "\t"
+                                                        + TestResource3.class.getName())
+                                        + " \\(file:/[^)]*\\).*",
+                                Pattern.DOTALL)));
     }
 
     @ParameterizedTest(name = "[" + INDEX_PLACEHOLDER + "] {0}")

--- a/api/src/test/java/org/creekservice/internal/service/api/ComponentModelTest.java
+++ b/api/src/test/java/org/creekservice/internal/service/api/ComponentModelTest.java
@@ -223,17 +223,21 @@ class ComponentModelTest {
                                                 + "Are you missing a Creek extension on the class or module path?"
                                                 + lineSeparator()
                                                 + "Known resource types: ["
-                                                + lineSeparator()
-                                                + "\t"
-                                                + TestResource2.class.getName())
-                                + " \\(file:/.*\\)"
-                                + quote(
-                                        ","
-                                                + lineSeparator()
-                                                + "\t"
-                                                + TestResource3.class.getName())
-                                + " \\(file:/.*\\)"
+                                                + lineSeparator())
+                                + ".*"
                                 + quote(lineSeparator() + "]")));
+
+        assertThat(
+                e.getMessage(),
+                matchesRegex(
+                        quote(lineSeparator() + "\t" + TestResource2.class.getName())
+                                + " \\(file:/.*\\)"));
+
+        assertThat(
+                e.getMessage(),
+                matchesRegex(
+                        quote("," + lineSeparator() + "\t" + TestResource3.class.getName())
+                                + " \\(file:/.*\\)"));
     }
 
     @ParameterizedTest(name = "[" + INDEX_PLACEHOLDER + "] {0}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,10 @@ subprojects {
 
     project.version = project.parent?.version!!
 
+    configurations.all {
+        resolutionStrategy.cacheChangingModulesFor(10, TimeUnit.MINUTES)
+    }
+
     extra.apply {
         set("creekBaseVersion", "0.2.0-SNAPSHOT")
         set("creekTestVersion", "0.2.0-SNAPSHOT")

--- a/test-java-nine-extension/src/main/java/org/creekservice/test/api/java/nine/service/extension/JavaNineExtensionProvider2.java
+++ b/test-java-nine-extension/src/main/java/org/creekservice/test/api/java/nine/service/extension/JavaNineExtensionProvider2.java
@@ -35,6 +35,7 @@ public final class JavaNineExtensionProvider2 implements CreekExtensionProvider 
         creek.model()
                 .addResource(Internal.class, new InternalHandler())
                 .addResource(Output.class, new OutputHandler());
+                
 
         return new Extension(creek.service());
     }

--- a/test-java-nine-extension/src/main/java/org/creekservice/test/api/java/nine/service/extension/JavaNineExtensionProvider2.java
+++ b/test-java-nine-extension/src/main/java/org/creekservice/test/api/java/nine/service/extension/JavaNineExtensionProvider2.java
@@ -35,7 +35,6 @@ public final class JavaNineExtensionProvider2 implements CreekExtensionProvider 
         creek.model()
                 .addResource(Internal.class, new InternalHandler())
                 .addResource(Output.class, new OutputHandler());
-                
 
         return new Extension(creek.service());
     }

--- a/test-java-nine-extension/src/main/java/org/creekservice/test/api/java/nine/service/extension/JavaNineExtensionProvider2.java
+++ b/test-java-nine-extension/src/main/java/org/creekservice/test/api/java/nine/service/extension/JavaNineExtensionProvider2.java
@@ -41,18 +41,18 @@ public final class JavaNineExtensionProvider2 implements CreekExtensionProvider 
 
     private static final class InternalHandler implements ResourceHandler<Internal> {
         @Override
-        public void validate(final Collection<Internal> resourceGroup) {}
+        public void validate(final Collection<? extends Internal> resourceGroup) {}
 
         @Override
-        public void ensure(final Collection<Internal> resources) {}
+        public void ensure(final Collection<? extends Internal> resources) {}
     }
 
     private static final class OutputHandler implements ResourceHandler<Output> {
         @Override
-        public void validate(final Collection<Output> resourceGroup) {}
+        public void validate(final Collection<? extends Output> resourceGroup) {}
 
         @Override
-        public void ensure(final Collection<Output> resources) {}
+        public void ensure(final Collection<? extends Output> resources) {}
     }
 
     public static final class Extension implements CreekExtension {

--- a/test-java-nine-extension/src/main/java/org/creekservice/test/internal/java/nine/service/extension/JavaNineExtensionProvider.java
+++ b/test-java-nine-extension/src/main/java/org/creekservice/test/internal/java/nine/service/extension/JavaNineExtensionProvider.java
@@ -38,9 +38,9 @@ public final class JavaNineExtensionProvider implements CreekExtensionProvider {
 
     private static final class InputHandler implements ResourceHandler<JavaNineExtensionInput> {
         @Override
-        public void validate(final Collection<JavaNineExtensionInput> resourceGroup) {}
+        public void validate(final Collection<? extends JavaNineExtensionInput> resourceGroup) {}
 
         @Override
-        public void ensure(final Collection<JavaNineExtensionInput> resources) {}
+        public void ensure(final Collection<? extends JavaNineExtensionInput> resources) {}
     }
 }


### PR DESCRIPTION
`ResourceHandler` generics were fixed to use `? extends`... update the repo code to be compatible.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended