### PR TITLE
Remove validate call from `ResourceHandler`.

### DIFF
--- a/test-java-nine-extension/src/main/java/org/creekservice/test/api/java/nine/service/extension/JavaNineExtensionProvider2.java
+++ b/test-java-nine-extension/src/main/java/org/creekservice/test/api/java/nine/service/extension/JavaNineExtensionProvider2.java
@@ -45,16 +45,10 @@ public final class JavaNineExtensionProvider2
 
     private static final class InternalHandler implements ResourceHandler<Internal> {
         @Override
-        public void validate(final Collection<? extends Internal> resourceGroup) {}
-
-        @Override
         public void ensure(final Collection<? extends Internal> resources) {}
     }
 
     private static final class OutputHandler implements ResourceHandler<Output> {
-        @Override
-        public void validate(final Collection<? extends Output> resourceGroup) {}
-
         @Override
         public void ensure(final Collection<? extends Output> resources) {}
     }

--- a/test-java-nine-extension/src/main/java/org/creekservice/test/internal/java/nine/service/extension/JavaNineExtensionProvider.java
+++ b/test-java-nine-extension/src/main/java/org/creekservice/test/internal/java/nine/service/extension/JavaNineExtensionProvider.java
@@ -40,9 +40,6 @@ public final class JavaNineExtensionProvider implements CreekExtensionProvider<J
 
     private static final class InputHandler implements ResourceHandler<JavaNineExtensionInput> {
         @Override
-        public void validate(final Collection<? extends JavaNineExtensionInput> resourceGroup) {}
-
-        @Override
         public void ensure(final Collection<? extends JavaNineExtensionInput> resources) {}
     }
 }


### PR DESCRIPTION
part of: https://github.com/creek-service/creek-kafka/issues/56

Given a service extension will be passed all components under test as part of the api passed to the initialize call, and that the extension will use the components' resource descriptors to initialize itself, and will therefore need to validate descriptors and that this is done _before_ the resource initializer can call validate... there is no point to then calling validate again here.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended