### PR TITLE
Make options super-type aware

### DIFF
--- a/api/src/main/java/org/creekservice/internal/service/api/util/SubTypeAwareMap.java
+++ b/api/src/main/java/org/creekservice/internal/service/api/util/SubTypeAwareMap.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.service.api.util;
+
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Specialised map impl that provides a {@link #getOrSub} and {@link #getOrSuper} method that
+ * supports lookups by subtype.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public final class SubTypeAwareMap<K, V> extends AbstractMap<Class<? extends K>, V>
+        implements Map<Class<? extends K>, V> {
+
+    private final Map<Class<? extends K>, V> types = new HashMap<>();
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public Set<Entry<Class<? extends K>, V>> entrySet() {
+        return types.entrySet();
+    }
+
+    @Override
+    public V put(final Class<? extends K> key, final V value) {
+        return types.put(key, value);
+    }
+
+    public Optional<V> getOrSub(final Class<? extends K> key) {
+        return find(key, e -> e.getKey().isAssignableFrom(key));
+    }
+
+    public Optional<V> getOrSuper(final Class<? extends K> key) {
+        return find(key, e -> key.isAssignableFrom(e.getKey()));
+    }
+
+    private Optional<V> find(
+            final Class<? extends K> key, final Predicate<Entry<Class<? extends K>, V>> filter) {
+        final V exact = types.get(key);
+        if (exact != null) {
+            return Optional.of(exact);
+        }
+
+        final Map<Class<? extends K>, V> found =
+                types.entrySet().stream()
+                        .filter(filter)
+                        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+        final Map<Class<? extends K>, V> reduced = removeSuperTypes(found);
+
+        switch (reduced.size()) {
+            case 1:
+                return Optional.of(reduced.values().iterator().next());
+            case 0:
+                return Optional.empty();
+            default:
+                throw new IllegalArgumentException(
+                        "Ambiguous entry. Multiple entries match supplied key: "
+                                + key.getName()
+                                + ". Could be any of "
+                                + reduced.keySet().stream()
+                                        .map(Class::getName)
+                                        .sorted()
+                                        .collect(Collectors.joining(", ", "[", "]")));
+        }
+    }
+
+    private Map<Class<? extends K>, V> removeSuperTypes(final Map<Class<? extends K>, V> types) {
+        return types.entrySet().stream()
+                .filter(
+                        e ->
+                                types.keySet().stream()
+                                        .filter(t -> !t.equals(e.getKey()))
+                                        .noneMatch(t -> e.getKey().isAssignableFrom(t)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/api/src/test/java/org/creekservice/internal/service/api/component/model/ComponentModelTest.java
+++ b/api/src/test/java/org/creekservice/internal/service/api/component/model/ComponentModelTest.java
@@ -184,8 +184,8 @@ class ComponentModelTest {
                 e.getMessage(),
                 is(
                         "Unable to determine most specific resource handler for type: "
-                                + "org.creekservice.internal.service.api.component.model.ComponentModelTest$TestResource4. "
-                                + "Could be any handler for any type in [BaseResource (provider), BaseResource2 (provider)]"));
+                                + "org.creekservice.internal.service.api.component.model.ComponentModelTest$TestResource4"));
+        assertThat(e.getCause().getMessage(), startsWith("Ambiguous entry."));
     }
 
     @Test

--- a/api/src/test/java/org/creekservice/internal/service/api/util/SubTypeAwareMapTest.java
+++ b/api/src/test/java/org/creekservice/internal/service/api/util/SubTypeAwareMapTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.service.api.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class SubTypeAwareMapTest {
+
+    private final SubTypeAwareMap<KeyType, String> map = new SubTypeAwareMap<>();
+
+    @Test
+    void shouldReturnEntrySet() {
+        // Given:
+        map.put(KeyTypeA.class, "a");
+
+        // Then:
+        assertThat(map, hasEntry(KeyTypeA.class, "a"));
+    }
+
+    @Test
+    void shouldReturnEmptyIfNotFound() {
+        assertThat(map.getOrSub(KeyTypeA.class), is(Optional.empty()));
+        assertThat(map.getOrSuper(KeyTypeA.class), is(Optional.empty()));
+    }
+
+    @Test
+    void shouldFindExactSub() {
+        // Given:
+        map.put(KeyTypeA.class, "a");
+
+        // Then:
+        assertThat(map.getOrSub(KeyTypeA.class), is(Optional.of("a")));
+    }
+
+    @Test
+    void shouldFindExactSuper() {
+        // Given:
+        map.put(KeyTypeA.class, "a");
+
+        // Then:
+        assertThat(map.getOrSuper(KeyTypeA.class), is(Optional.of("a")));
+    }
+
+    @Test
+    void shouldFindBySubType() {
+        // Given:
+        map.put(KeyType.class, "base");
+
+        // Then:
+        assertThat(map.getOrSub(KeyTypeA.class), is(Optional.of("base")));
+    }
+
+    @Test
+    void shouldFindBySuperType() {
+        // Given:
+        map.put(KeyTypeA.class, "a");
+
+        // Then:
+        assertThat(map.getOrSuper(KeyType.class), is(Optional.of("a")));
+    }
+
+    @Test
+    void shouldFindMostSpecificSubType() {
+        // Given:
+        map.put(KeyType.class, "base");
+        map.put(KeyTypeA.class, "a");
+
+        // Then:
+        assertThat(map.getOrSub(KeyTypeAA.class), is(Optional.of("a")));
+    }
+
+    @Test
+    void shouldFindMostSpecificSuperType() {
+        // Given:
+        map.put(KeyTypeAA.class, "aa");
+        map.put(KeyTypeA.class, "a");
+
+        // Then:
+        assertThat(map.getOrSuper(KeyType.class), is(Optional.of("aa")));
+    }
+
+    @Test
+    void shouldThrowOnAmbiguousSubType() {
+        // Given:
+        map.put(KeyType.class, "base");
+        map.put(KeyTypeA.class, "a");
+        map.put(KeyTypeB.class, "b");
+
+        // When:
+        final Exception e =
+                assertThrows(RuntimeException.class, () -> map.getOrSub(KeyTypeM.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is(
+                        "Ambiguous entry. Multiple entries match supplied key: "
+                                + "org.creekservice.internal.service.api.util.SubTypeAwareMapTest$KeyTypeM. "
+                                + "Could be any of ["
+                                + "org.creekservice.internal.service.api.util.SubTypeAwareMapTest$KeyTypeA, "
+                                + "org.creekservice.internal.service.api.util.SubTypeAwareMapTest$KeyTypeB"
+                                + "]"));
+    }
+
+    @Test
+    void shouldThrowOnAmbiguousSuperType() {
+        // Given:
+        map.put(KeyTypeA.class, "a");
+        map.put(KeyTypeB.class, "b");
+
+        // When:
+        final Exception e =
+                assertThrows(RuntimeException.class, () -> map.getOrSuper(KeyType.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is(
+                        "Ambiguous entry. Multiple entries match supplied key: "
+                                + "org.creekservice.internal.service.api.util.SubTypeAwareMapTest$KeyType. "
+                                + "Could be any of ["
+                                + "org.creekservice.internal.service.api.util.SubTypeAwareMapTest$KeyTypeA, "
+                                + "org.creekservice.internal.service.api.util.SubTypeAwareMapTest$KeyTypeB"
+                                + "]"));
+    }
+
+    private interface KeyType {}
+
+    private interface KeyTypeA extends KeyType {}
+
+    private interface KeyTypeAA extends KeyTypeA {}
+
+    private interface KeyTypeB extends KeyType {}
+
+    private interface KeyTypeM extends KeyTypeAA, KeyTypeB {}
+}

--- a/extension/src/main/java/org/creekservice/api/service/extension/option/OptionCollection.java
+++ b/extension/src/main/java/org/creekservice/api/service/extension/option/OptionCollection.java
@@ -25,9 +25,13 @@ public interface OptionCollection {
     /**
      * Retrieve an option by type.
      *
+     * <p>The supplied {@code type} can also be a super type or a registered option.
+     *
      * @param type the type of option to retrieve.
      * @param <T> the type of the option to retrieve.
      * @return the option, if present, otherwise {@code empty}.
+     * @throws RuntimeException if it is ambiguous which option should be returned, i.e. if multiple
+     *     as subtypes of {@code type}.
      */
     <T extends CreekExtensionOptions> Optional<T> get(Class<T> type);
 }


### PR DESCRIPTION
Requried by: https://github.com/creek-service/creek-kafka/issues/56

The kafka clients and streams extensions need to share a common set of properties. This requires that we can look up options by a super type.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended