### PR TITLE
Fix concurrent mod in tests.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze
+    if: ${{ github.run_number != 1 }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/context/src/test/java/org/creekservice/internal/service/context/ContextBuilderTest.java
+++ b/context/src/test/java/org/creekservice/internal/service/context/ContextBuilderTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -55,6 +56,8 @@ import org.creekservice.internal.service.context.temporal.TestClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
@@ -66,6 +69,8 @@ import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
+@Isolated // This test uses @SetEnvironmentVariable, which modifies global env
+@Execution(SAME_THREAD) // ...this isn't thread-safe. So isolate from other tests.
 class ContextBuilderTest {
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)

--- a/context/src/test/java/org/creekservice/internal/service/context/temporal/SystemEnvClockLoaderTest.java
+++ b/context/src/test/java/org/creekservice/internal/service/context/temporal/SystemEnvClockLoaderTest.java
@@ -22,16 +22,21 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 import org.creekservice.api.base.type.temporal.Clock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+@Isolated // This test uses @SetEnvironmentVariable, which modifies global env
+@Execution(SAME_THREAD) // ...this isn't thread-safe. So isolate from other tests.
 class SystemEnvClockLoaderTest {
 
     @Mock private Clock defaultClock;


### PR DESCRIPTION
Affected tests were using the @SetEnvironmentVariable. Under the hoods this is modifying global state, i.e. the map of env vars, and the map isn't thread-safe.

Fix is to isolate the affected tests: not running them concurrently with other tests.
