### PR TITLE
Add validation callback to `ResourceHandler`

### DIFF
--- a/context/src/main/java/org/creekservice/internal/service/context/ContextBuilder.java
+++ b/context/src/main/java/org/creekservice/internal/service/context/ContextBuilder.java
@@ -185,15 +185,17 @@ public final class ContextBuilder implements CreekServices.Builder {
 
     private ResourceInitializer resourceInitializer() {
         return resourceInitializerFactory.build(
-                new ResourceInitializer.ResourceCreator() {
-                    @SuppressWarnings({"unchecked", "rawtypes"})
+                new ResourceInitializer.Callbacks() {
+                    @Override
+                    public <T extends ResourceDescriptor> void validate(
+                            final Class<T> type, final Collection<T> resourceGroup) {
+                        api.components().model().resourceHandler(type).validate(resourceGroup);
+                    }
+
                     @Override
                     public <T extends ResourceDescriptor & OwnedResource> void ensure(
-                            final Collection<T> creatableResources) {
-                        api.components()
-                                .model()
-                                .resourceHandler(creatableResources.iterator().next().getClass())
-                                .ensure((Collection) creatableResources);
+                            final Class<T> type, final Collection<T> creatableResources) {
+                        api.components().model().resourceHandler(type).ensure(creatableResources);
                     }
                 });
     }
@@ -251,7 +253,7 @@ public final class ContextBuilder implements CreekServices.Builder {
 
     @VisibleForTesting
     interface ResourceInitializerFactory {
-        ResourceInitializer build(ResourceInitializer.ResourceCreator resourceCreator);
+        ResourceInitializer build(ResourceInitializer.Callbacks callbacks);
     }
 
     @VisibleForTesting

--- a/extension/src/main/java/org/creekservice/api/service/extension/component/model/ResourceHandler.java
+++ b/extension/src/main/java/org/creekservice/api/service/extension/component/model/ResourceHandler.java
@@ -27,6 +27,19 @@ import org.creekservice.api.platform.metadata.ResourceDescriptor;
 public interface ResourceHandler<T extends ResourceDescriptor> {
 
     /**
+     * Validate that all the supplied {@code resources} consistently represent the same resource.
+     *
+     * <p>There is often multiple resource descriptors describing the same resource present in the
+     * system. For example, both input and output descriptors for the same resource. Any
+     * inconsistencies in the details of the resource between these descriptors can lead to bugs.
+     *
+     * @param resources the set of resources that all share the same {@link
+     *     ResourceDescriptor#id()}.
+     * @throws RuntimeException with the details of any inconsistencies.
+     */
+    void validate(Collection<? extends T> resources);
+
+    /**
      * Ensure the supplied external {@code creatableResources} exist.
      *
      * <p>Instructs an extension to ensure the resources described by the supplied descriptor exist

--- a/extension/src/test/java/org/creekservice/api/service/extension/component/model/ResourceHandlerTest.java
+++ b/extension/src/test/java/org/creekservice/api/service/extension/component/model/ResourceHandlerTest.java
@@ -43,6 +43,10 @@ class ResourceHandlerTest {
     private interface TestResource extends ResourceDescriptor {}
 
     private static final class TestResourceHandler implements ResourceHandler<TestResource> {
+
+        @Override
+        public void validate(final Collection<? extends TestResource> resources) {}
+
         @Override
         public void prepare(final Collection<? extends TestResource> resources) {}
     }

--- a/test-java-nine-extension/src/main/java/org/creekservice/test/api/java/nine/service/extension/JavaNineExtensionProvider2.java
+++ b/test-java-nine-extension/src/main/java/org/creekservice/test/api/java/nine/service/extension/JavaNineExtensionProvider2.java
@@ -24,9 +24,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
+import org.creekservice.api.platform.metadata.ComponentInput;
 import org.creekservice.api.platform.metadata.ComponentInternal;
 import org.creekservice.api.platform.metadata.ComponentOutput;
 import org.creekservice.api.platform.metadata.OwnedResource;
+import org.creekservice.api.platform.metadata.UnownedResource;
 import org.creekservice.api.service.extension.CreekExtension;
 import org.creekservice.api.service.extension.CreekExtensionProvider;
 import org.creekservice.api.service.extension.CreekService;
@@ -44,6 +46,7 @@ public final class JavaNineExtensionProvider2
 
         api.components()
                 .model()
+                .addResource(Input.class, ext.inputHandler)
                 .addResource(Internal.class, ext.internalHandler)
                 .addResource(Output.class, ext.outputHandler);
 
@@ -55,6 +58,7 @@ public final class JavaNineExtensionProvider2
         private static final String NAME = "java9_2";
 
         private final Collection<? extends ComponentDescriptor> components;
+        private final InputHandler inputHandler = new InputHandler();
         private final InternalHandler internalHandler = new InternalHandler();
         private final OutputHandler outputHandler = new OutputHandler();
         private final LinkedHashMap<String, Object> executionOrder = new LinkedHashMap<>();
@@ -76,7 +80,25 @@ public final class JavaNineExtensionProvider2
             return new LinkedHashMap<>(executionOrder);
         }
 
+        private final class InputHandler implements ResourceHandler<Input> {
+
+            @Override
+            public void validate(final Collection<? extends Input> resources) {
+                executionOrder.put("input validate", resources);
+            }
+
+            @Override
+            public void prepare(final Collection<? extends Input> resources) {
+                executionOrder.put("input prepare", resources);
+            }
+        }
+
         private final class InternalHandler implements ResourceHandler<Internal> {
+
+            @Override
+            public void validate(final Collection<? extends Internal> resources) {
+                executionOrder.put("internal validate", resources);
+            }
 
             @Override
             public void prepare(final Collection<? extends Internal> resources) {
@@ -86,6 +108,11 @@ public final class JavaNineExtensionProvider2
 
         private final class OutputHandler implements ResourceHandler<Output> {
             @Override
+            public void validate(final Collection<? extends Output> resources) {
+                executionOrder.put("output validate", resources);
+            }
+
+            @Override
             public void ensure(final Collection<? extends Output> creatableResources) {
                 executionOrder.put("output ensure", creatableResources);
             }
@@ -94,6 +121,18 @@ public final class JavaNineExtensionProvider2
             public void prepare(final Collection<? extends Output> resources) {
                 executionOrder.put("output prepare", resources);
             }
+        }
+    }
+
+    public static final class Input implements ComponentInput, UnownedResource {
+
+        private final URI id = URI.create("java9-2:test-resource-input");
+
+        public Input() {}
+
+        @Override
+        public URI id() {
+            return id;
         }
     }
 

--- a/test-java-nine-extension/src/main/java/org/creekservice/test/internal/java/nine/service/extension/JavaNineExtensionProvider.java
+++ b/test-java-nine-extension/src/main/java/org/creekservice/test/internal/java/nine/service/extension/JavaNineExtensionProvider.java
@@ -39,6 +39,9 @@ public final class JavaNineExtensionProvider implements CreekExtensionProvider<J
 
     private static final class InputHandler implements ResourceHandler<JavaNineExtensionInput> {
         @Override
+        public void validate(final Collection<? extends JavaNineExtensionInput> resources) {}
+
+        @Override
         public void ensure(final Collection<? extends JavaNineExtensionInput> creatableResources) {}
 
         @Override


### PR DESCRIPTION
Fixes: https://github.com/creek-service/creek-service/issues/244
