### PR TITLE
Support Nested resources

### DIFF
--- a/extension/src/main/java/org/creekservice/api/service/extension/component/model/ResourceHandler.java
+++ b/extension/src/main/java/org/creekservice/api/service/extension/component/model/ResourceHandler.java
@@ -27,17 +27,18 @@ import org.creekservice.api.platform.metadata.ResourceDescriptor;
 public interface ResourceHandler<T extends ResourceDescriptor> {
 
     /**
-     * Validate that all the supplied {@code resources} consistently represent the same resource.
+     * Validate that all the supplied {@code resourceGroup} consistently represent the same
+     * resource.
      *
      * <p>There is often multiple resource descriptors describing the same resource present in the
      * system. For example, both input and output descriptors for the same resource. Any
      * inconsistencies in the details of the resource between these descriptors can lead to bugs.
      *
-     * @param resources the set of resources that all share the same {@link
+     * @param resourceGroup the set of resources that all share the same {@link
      *     ResourceDescriptor#id()}.
      * @throws RuntimeException with the details of any inconsistencies.
      */
-    void validate(Collection<? extends T> resources);
+    void validate(Collection<? extends T> resourceGroup);
 
     /**
      * Ensure the supplied external {@code creatableResources} exist.
@@ -49,7 +50,8 @@ public interface ResourceHandler<T extends ResourceDescriptor> {
      * exists, but does not match the expected configuration.
      *
      * @param creatableResources the resource instances to ensure exists and are initialized.
-     *     Resources passed will be {@link ResourceDescriptor#isCreatable creatable}.
+     *     Resources passed will be {@link org.creekservice.api.platform.metadata.CreatableResource
+     *     creatable}.
      */
     default void ensure(Collection<? extends T> creatableResources) {
         throw new UnsupportedOperationException("Not a handler of owned resources");

--- a/extension/src/test/java/org/creekservice/api/service/extension/component/model/ResourceHandlerTest.java
+++ b/extension/src/test/java/org/creekservice/api/service/extension/component/model/ResourceHandlerTest.java
@@ -45,7 +45,7 @@ class ResourceHandlerTest {
     private static final class TestResourceHandler implements ResourceHandler<TestResource> {
 
         @Override
-        public void validate(final Collection<? extends TestResource> resources) {}
+        public void validate(final Collection<? extends TestResource> resourceGroup) {}
 
         @Override
         public void prepare(final Collection<? extends TestResource> resources) {}

--- a/test-java-eight/src/test/java/org/creekservice/test/service/eight/CreekServicesTest.java
+++ b/test-java-eight/src/test/java/org/creekservice/test/service/eight/CreekServicesTest.java
@@ -113,10 +113,20 @@ class CreekServicesTest {
 
         final List<String> outputOrder =
                 executionOrder.keySet().stream()
-                        .filter(k -> k.startsWith("output "))
+                        .filter(k -> k.startsWith("output ") || k.startsWith("inner "))
                         .collect(Collectors.toList());
 
-        assertThat(outputOrder, is(List.of("output validate", "output ensure", "output prepare")));
+        // Prepare doesn't have guaranteed order:
+        assertThat(
+                outputOrder,
+                is(
+                        List.of(
+                                "inner validate",
+                                "output validate",
+                                "inner ensure",
+                                "output ensure",
+                                "inner prepare",
+                                "output prepare")));
     }
 
     @Test

--- a/test-java-nine-extension/src/main/java/org/creekservice/test/internal/java/nine/service/extension/JavaNineExtensionProvider.java
+++ b/test-java-nine-extension/src/main/java/org/creekservice/test/internal/java/nine/service/extension/JavaNineExtensionProvider.java
@@ -39,7 +39,7 @@ public final class JavaNineExtensionProvider implements CreekExtensionProvider<J
 
     private static final class InputHandler implements ResourceHandler<JavaNineExtensionInput> {
         @Override
-        public void validate(final Collection<? extends JavaNineExtensionInput> resources) {}
+        public void validate(final Collection<? extends JavaNineExtensionInput> resourceGroup) {}
 
         @Override
         public void ensure(final Collection<? extends JavaNineExtensionInput> creatableResources) {}

--- a/test-java-nine/src/test/java/org/creekservice/test/service/java/nine/CreekServicesTest.java
+++ b/test-java-nine/src/test/java/org/creekservice/test/service/java/nine/CreekServicesTest.java
@@ -48,6 +48,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+@SuppressWarnings("resource")
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class CreekServicesTest {


### PR DESCRIPTION
Continues work done in platform to add nested resource support: https://github.com/creek-service/creek-platform/pull/195

The `ContextBuilder` will now ensure all resource collection includes nested resources, and ensures `prepare` is called on nested resources first.
