### PR TITLE
upgrade Java 11 to 17

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
     gradlePluginPortal()
 }
 
-val jvmTargetVer = JavaLanguageVersion.of(11)
+val jvmTargetVer = JavaLanguageVersion.of(17)
 
 java {
     toolchain.languageVersion.set(jvmTargetVer)

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -94,7 +94,7 @@ tasks.test {
 
 spotless {
     java {
-        googleJavaFormat("1.15.0").aosp().reflowLongStrings()
+        googleJavaFormat("1.25.2").aosp().reflowLongStrings()
         leadingTabsToSpaces()
         importOrder()
         removeUnusedImports()

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -43,7 +43,7 @@ group = "org.creekservice"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 

--- a/test-java-nine-extension/src/main/java/org/creekservice/test/api/java/nine/service/extension/JavaNineExtensionProvider2.java
+++ b/test-java-nine-extension/src/main/java/org/creekservice/test/api/java/nine/service/extension/JavaNineExtensionProvider2.java
@@ -180,6 +180,8 @@ public final class JavaNineExtensionProvider2
 
         private final URI id = URI.create("java9-2:test-resource-output");
 
+        public Output() {}
+
         @Override
         public URI id() {
             return id;


### PR DESCRIPTION
Upgrades Java version from 11 to 17 in Gradle build configuration.

## Files changed
- `buildSrc/build.gradle.kts`: Updated `JavaLanguageVersion.of(11)` to `JavaLanguageVersion.of(17)` for the buildSrc toolchain
- `buildSrc/src/main/kotlin/creek-common-convention.gradle.kts`: Updated `JavaLanguageVersion.of(11)` to `JavaLanguageVersion.of(17)` for all Java modules

Note: Workflow files already reference Java 17.