### PR TITLE
Switch coverage reporting from Coveralls to Codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,12 +42,13 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
       - name: Build
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          CI_NAME: github-actions
-          CI_JOB_ID: ${{ github.run_id }}
-          CI_PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: ./gradlew build coveralls
+        run: ./gradlew build jacocoTestReport
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: '**/build/reports/jacoco/test/jacocoTestReport.xml'
+          fail_ci_if_error: true
       - name: Upload Reports
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -39,7 +39,6 @@ kotlin {
 dependencies {
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.2.2")                // https://plugins.gradle.org/plugin/com.github.spotbugs
     implementation("com.diffplug.spotless:spotless-plugin-gradle:8.4.0")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
-    implementation("gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.12.2")   // https://plugins.gradle.org/plugin/com.github.kt3k.coveralls
     implementation("org.javamodularity:moduleplugin:1.8.15")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
     implementation("io.github.gradle-nexus:publish-plugin:2.0.0")                           // https://plugins.gradle.org/plugin/io.github.gradle-nexus.publish-plugin
     implementation("com.gradle.publish:plugin-publish-plugin:1.3.1")                        // https://plugins.gradle.org/plugin/com.gradle.plugin-publish

--- a/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
@@ -15,9 +15,10 @@
  */
 
 /**
- * Standard coverage configuration of Creek projects, utilising Jacoco and Coveralls.io
+ * Standard coverage configuration of Creek projects, utilising Jacoco and Codecov.
  *
  * <p>Versions:
+ *  - 1.4: Switch from Coveralls to Codecov; remove multi-module report aggregation
  *  - 1.3: remove deprecated use of $buildDir
  *  - 1.2: Apply to root project only
  */
@@ -25,7 +26,6 @@
 plugins {
     java
     jacoco
-    id("com.github.kt3k.coveralls")
 }
 
 repositories {
@@ -35,42 +35,10 @@ repositories {
 allprojects {
     apply(plugin = "java")
 
-    tasks.withType<JacocoReport>().configureEach{
+    tasks.withType<JacocoReport>().configureEach {
         dependsOn(tasks.test)
-    }
-}
-
-val coverage = tasks.register<JacocoReport>("coverage") {
-    group = "creek"
-    description = "Generates an aggregate code coverage report"
-
-    val coverageReportTask = this
-
-    allprojects {
-        val proj = this
-        // Roll results of each test task into the main coverage task:
-        proj.tasks.matching { it.extensions.findByType<JacocoTaskExtension>() != null }.forEach {
-            coverageReportTask.sourceSets(proj.sourceSets.main.get())
-            coverageReportTask.executionData(it.extensions.findByType<JacocoTaskExtension>()!!.destinationFile)
-            coverageReportTask.dependsOn(it)
+        reports {
+            xml.required.set(true)
         }
     }
-
-    reports {
-        xml.required.set(true)
-        html.required.set(true)
-    }
-}
-
-coveralls {
-    sourceDirs = allprojects.flatMap{it.sourceSets.main.get().allSource.srcDirs}.map{it.toString()}
-    jacocoReportPath = layout.buildDirectory.file("reports/jacoco/coverage/coverage.xml")
-}
-
-tasks.coveralls {
-    group = "creek"
-    description = "Uploads the aggregated coverage report to Coveralls"
-
-    dependsOn(coverage)
-    onlyIf{System.getenv("CI") != null}
 }


### PR DESCRIPTION
## Summary

Replaces [Coveralls.io](https://coveralls.io) with [Codecov](https://codecov.io) for coverage reporting.

## Changes

### Gradle
- **`buildSrc/build.gradle.kts`**: Remove `coveralls-gradle-plugin` dependency
- **`buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts`**:
  - Remove `com.github.kt3k.coveralls` plugin
  - Remove multi-module coverage aggregation task (Codecov handles merging multiple reports natively)
  - Configure per-module `jacocoTestReport` tasks to generate XML

### GitHub Workflow
- **`.github/workflows/build.yml`**:
  - Remove `COVERALLS_REPO_TOKEN`, `CI_NAME`, `CI_JOB_ID`, `CI_PULL_REQUEST` env vars
  - Run `./gradlew build jacocoTestReport` (explicit report generation)
  - Add `codecov/codecov-action@v6.0.0` step using org-wide `CODECOV_TOKEN` secret

## Notes
- The Codecov app has been added to the creek-service org and an org-wide `CODECOV_TOKEN` secret is configured
- Each submodule generates its own `jacocoTestReport.xml`; Codecov merges them automatically